### PR TITLE
Add PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,30 @@
+name: PR Preview
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages (PR preview)
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages-pr-${{ github.event.pull_request.number }}
+


### PR DESCRIPTION
## Summary
- add GitHub Action to publish PR previews to ephemeral branches

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' in App.test.tsx)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842c18f8268832e97b93a76f5f941ff