### PR TITLE
Refactor footer styles and cleanup logs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import Header from './patterns/Header';
 import Home from './pages/Home';
 import Listen from './pages/Listen';
 import NotFound from './pages/NotFound';
-import Work from './pages/Gallery';
+import Gallery from './pages/Gallery';
 
 import styles from './App.module.css';
 
@@ -27,7 +27,7 @@ const App: React.FC = () => {
           <Route path="/listen" element={<Listen />} />
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
-          <Route path="/gallery" element={<Work onOverlayStateChange={handleOverlayState} />} />
+          <Route path="/gallery" element={<Gallery onOverlayStateChange={handleOverlayState} />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
         {!isOverlayActive && <Footer />}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -49,7 +49,7 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
         </button>
       )}
       {post.media && post.contentType === 'image' && (
-        <img src={post.media} alt="" className={styles.media} />
+        <img src={post.media} alt={post.title} className={styles.media} />
       )}
       {post.media && post.contentType === 'video' && (
         <video src={post.media} controls className={styles.media} />

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -38,8 +38,7 @@ const Contact: React.FC = () => {
       },
       '-BdVWUzt4g0H07ZtM'
     )
-    .then((response) => {
-      console.log('Email sent successfully!', response);
+    .then(() => {
       setIsModalOpen(true);
     })
     .catch((error) => {

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -60,7 +60,7 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
   return (
     <div className={styles['gallery-container']}>
       {loading && <Spinner />}
-      <div className={styles['gallery-content']} onLoad={handleContentLoad}>
+      <div className={styles['gallery-content']}>
         <h2>Gallery</h2>
         {images.map((image, index) => (
           <div key={index}>
@@ -70,6 +70,7 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
               alt={image.caption}
               style={{ width: '100%', borderRadius: '8px', marginTop: '1rem' }}
               onClick={() => openOverlay(index)}
+              onLoad={index === 0 ? handleContentLoad : undefined}
             />
             <figcaption style={{ textAlign: 'center', marginTop: '0.5rem', fontStyle: 'italic', color: '#fff' }}>
               {image.caption}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,9 +26,7 @@ const Home: React.FC = () => {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          console.log('Entry:', entry);
           if (entry.isIntersecting && autoLoads < 2) {
-            console.log('Autoload triggered');
             setVisibleCount((v) => Math.min(v + 1, posts.length));
             setAutoLoads((l) => l + 1);
           }
@@ -39,13 +37,11 @@ const Home: React.FC = () => {
 
     const current = sentinelRef.current;
     if (current) {
-      console.log('Sentinel observed');
       observer.observe(current);
     }
 
     return () => {
       if (current) {
-        console.log('Sentinel unobserved');
         observer.unobserve(current);
       }
     };

--- a/src/patterns/Footer.tsx
+++ b/src/patterns/Footer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { SocialIcon } from 'react-social-icons';
-import './Footer.module.css';
+import styles from './Footer.module.css';
 
 const Footer: React.FC = () => {
   return (
-    <footer className="footer">
-      <div className="social-links">
+    <footer className={styles.footer}>
+      <div className={styles['social-links']}>
         <SocialIcon label="Spotify" url="https://open.spotify.com/artist/54Vv9rlCqX2nW2V0tXw33q?si=TCP19UlhTpyHb7w0UOukmg" bgColor="#000" fgColor="#fff" style={{ width: '2rem', height: '2rem' }} title="Spotify" />
         <SocialIcon label="Soundcloud" url="https://soundcloud.com/randomgorsey" bgColor="#000" fgColor="#fff" style={{ width: '2rem', height: '2rem' }} title="Soundcloud" />
         <SocialIcon label="Instagram" url="https://www.instagram.com/random_gorsey?igsh=am42eWcwNGdnY3hm&utm_source=qr" bgColor="#000" fgColor="#fff" style={{ width: '2rem', height: '2rem' }} title="Instagram" />
@@ -23,7 +23,7 @@ const Footer: React.FC = () => {
           />
         </a>
       </div>
-      <p className="footerCopyright">
+      <p className={styles['footer-copyright']}>
         &copy; {new Date().getFullYear()} &nbsp;Random Gorsey. Rights reserved.&nbsp;
         <a
           href="https://www.instagram.com/digitaltableteur"
@@ -31,7 +31,9 @@ const Footer: React.FC = () => {
           rel="noopener noreferrer"
           style={{ display: 'inline-flex', alignItems: 'center', textDecoration: 'none', color: '#fff' }}
         >
-          <span title="Site by Digitaltableteur" className="hideOnMobile">Site by</span>
+          <span title="Site by Digitaltableteur" className={styles['hide-on-mobile']}>
+            Site by
+          </span>
           <img
         src="/images/dt.svg"
         title="Site by Digitaltableteur"


### PR DESCRIPTION
## Summary
- wire Footer CSS modules correctly
- remove console logging noise
- show gallery loader only until first image loads
- fix alt text and minor naming

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d4c7a8e50832ebb91f927a49c2fae