### PR TITLE
Add cookie consent modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-754TS7FXNC"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-754TS7FXNC');
-    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Home from './pages/Home';
 import Listen from './pages/Listen';
 import NotFound from './pages/NotFound';
 import Gallery from './pages/Gallery';
+import CookieConsent from './components/CookieConsent';
 
 import styles from './App.module.css';
 
@@ -31,6 +32,7 @@ const App: React.FC = () => {
           <Route path="*" element={<NotFound />} />
         </Routes>
         {!isOverlayActive && <Footer />}
+        <CookieConsent />
       </div>
     </HashRouter>
   );

--- a/src/components/CookieConsent.module.css
+++ b/src/components/CookieConsent.module.css
@@ -1,0 +1,13 @@
+@import url("../variables.css");
+
+.content {
+  font-family: "Europa Regular", sans-serif;
+  text-align: center;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import Modal from './Modal';
+import Button from './Button';
+import styles from './CookieConsent.module.css';
+
+const COOKIE_NAME = 'cookieConsent';
+
+const getCookie = (): string | null => {
+  const match = document.cookie.match(new RegExp('(^| )' + COOKIE_NAME + '=([^;]+)'));
+  return match ? match[2] : null;
+};
+
+const setCookie = (value: string) => {
+  document.cookie = `${COOKIE_NAME}=${value}; path=/; max-age=${60 * 60 * 24 * 365}`;
+};
+
+const loadGoogleAnalytics = () => {
+  if (document.getElementById('ga-script')) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://www.googletagmanager.com/gtag/js?id=G-754TS7FXNC';
+  script.id = 'ga-script';
+  document.head.appendChild(script);
+
+  const script2 = document.createElement('script');
+  script2.innerHTML = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-754TS7FXNC');
+  `;
+  document.head.appendChild(script2);
+};
+
+const CookieConsent: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const consent = getCookie();
+    if (!consent) {
+      setOpen(true);
+    } else if (consent === 'all') {
+      loadGoogleAnalytics();
+    }
+  }, []);
+
+  const acceptAll = () => {
+    setCookie('all');
+    loadGoogleAnalytics();
+    setOpen(false);
+  };
+
+  const acceptNecessary = () => {
+    setCookie('necessary');
+    setOpen(false);
+  };
+
+  return (
+    <Modal isOpen={open} onClose={acceptNecessary}>
+      <div className={styles.content}>
+        <h2>Cookie Notice</h2>
+        <p>
+          We use cookies to remember your preferences and to analyze how visitors
+          interact with our site. Accepting all cookies allows us to use Google
+          Analytics for statistics. You can also choose to keep only the cookies
+          necessary for the website to function.
+        </p>
+        <div className={styles.actions}>
+          <Button variant="secondary" onClick={acceptNecessary}>
+            Only necessary
+          </Button>
+          <Button onClick={acceptAll}>Accept all</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CookieConsent;

--- a/src/components/__tests__/CookieConsent.test.tsx
+++ b/src/components/__tests__/CookieConsent.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CookieConsent from '../CookieConsent';
+
+const setCookieMock = () => {
+  Object.defineProperty(document, 'cookie', {
+    writable: true,
+    value: '',
+  });
+};
+
+describe('CookieConsent Component', () => {
+  beforeEach(() => {
+    setCookieMock();
+  });
+
+  it('shows modal when no consent cookie is present', () => {
+    render(<CookieConsent />);
+    expect(screen.getByText(/cookie notice/i)).toBeInTheDocument();
+  });
+
+  it('sets cookie and closes on accept all', () => {
+    render(<CookieConsent />);
+    fireEvent.click(screen.getByText(/accept all/i));
+    expect(document.cookie).toContain('cookieConsent=all');
+  });
+});


### PR DESCRIPTION
## Summary
- add CookieConsent component with Accept all and Only necessary options
- style CookieConsent modal
- insert CookieConsent into App layout
- remove Google Analytics script from index.html
- add simple tests for CookieConsent

## Testing
- `npm test --silent` *(fails: Cannot find module './invariant')*

------
https://chatgpt.com/codex/tasks/task_e_684d8478ea6c832e8d238d6264deab97