### PR TITLE
Add discography page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Home from './pages/Home';
 import Listen from './pages/Listen';
 import NotFound from './pages/NotFound';
 import Gallery from './pages/Gallery';
+import Discography from './pages/Discography';
 import CookieConsent from './components/CookieConsent';
 
 import styles from './App.module.css';
@@ -28,6 +29,7 @@ const App: React.FC = () => {
           <Route path="/listen" element={<Listen />} />
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="/discography" element={<Discography />} />
           <Route path="/gallery" element={<Gallery onOverlayStateChange={handleOverlayState} />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Discography.module.css
+++ b/src/pages/Discography.module.css
@@ -1,0 +1,42 @@
+@import url("../variables.css");
+
+.discography-container {
+  padding: 2rem;
+  font-family: "Europa Regular", sans-serif;
+  background-color: var(--color-orange);
+  color: var(--color-blue);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.discography-container h2 {
+  font-family: "Tschick Bold", sans-serif;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.release-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.release img {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.release h3 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+@media (width <= 800px) {
+  .discography-container {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+}

--- a/src/pages/Discography.tsx
+++ b/src/pages/Discography.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import styles from './Discography.module.css';
+
+interface Release {
+  title: string;
+  catalog: string;
+  year: number;
+}
+
+const releases: Release[] = [
+  {
+    title: 'So Long Spectrum',
+    catalog: 'FIRGO2100004',
+    year: 2022,
+  },
+  {
+    title: 'The Customer is Always Right EP',
+    catalog: 'RDGY 01',
+    year: 2021,
+  },
+];
+
+const Discography: React.FC = () => (
+  <motion.div
+    className={styles['discography-container']}
+    initial={{ opacity: 0, y: 20 }}
+    animate={{ opacity: 1, y: 0 }}
+    transition={{ duration: 0.4 }}
+  >
+    <h2>Discography</h2>
+    <div className={styles['release-grid']}>
+      {releases.map((release) => (
+        <div key={release.catalog} className={styles.release}>
+          <img
+            src="https://via.placeholder.com/200"
+            alt={release.title}
+            width={200}
+            height={200}
+          />
+          <h3>{release.title}</h3>
+          <p>
+            {release.catalog} · {release.year}
+          </p>
+        </div>
+      ))}
+    </div>
+  </motion.div>
+);
+
+export default Discography;

--- a/src/pages/__tests__/Discography.test.tsx
+++ b/src/pages/__tests__/Discography.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Discography from '../Discography';
+
+describe('Discography Page', () => {
+  test('renders release information', () => {
+    render(<Discography />);
+    expect(screen.getByText('Discography')).toBeInTheDocument();
+    expect(screen.getByText('So Long Spectrum')).toBeInTheDocument();
+    expect(screen.getByText(/FIRGO2100004/)).toBeInTheDocument();
+    expect(screen.getByText('The Customer is Always Right EP')).toBeInTheDocument();
+    expect(screen.getByText(/RDGY 01/)).toBeInTheDocument();
+  });
+});

--- a/src/patterns/Header.tsx
+++ b/src/patterns/Header.tsx
@@ -13,6 +13,7 @@ const Header: React.FC = () => {
           <li><a href="#/listen" title="Go to Listen page">Listen</a></li>
           <li><a href="#/about" title="Info about RG">About</a></li>
           <li><a href="#/contact" title="Contact RG">Contact</a></li>
+          <li><a href="#/discography" title="View Discography">Discography</a></li>
           <li><a href="#/gallery" title="View Gallery">Gallery</a></li>
         </ul>
       </nav>

--- a/src/patterns/__tests__/Header.test.tsx
+++ b/src/patterns/__tests__/Header.test.tsx
@@ -9,6 +9,7 @@ describe('Header Pattern', () => {
     expect(screen.getByText('Listen')).toBeInTheDocument();
     expect(screen.getByText('About')).toBeInTheDocument();
     expect(screen.getByText('Contact')).toBeInTheDocument();
+    expect(screen.getByText('Discography')).toBeInTheDocument();
     expect(screen.getByText('Gallery')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
- create `Discography` page
- style discography page
- add route and header link
- update header unit test
- add discography tests

## 🔔 Related Issue
- Requested in conversation

## 📖 What?
- Adds simple page for release listing with placeholder artwork

## 🤔 Why?
- Provide discography information on the site

## 🤖 Testing
- `npm test` *(fails: Cannot find module './invariant')*

------
https://chatgpt.com/codex/tasks/task_e_68555cebc39c832ea81882249bbd832d