### PR TITLE
Improve SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The site will be available at [http://localhost:3000](http://localhost:3000). An
 - **`npm run build-storybook`** – generate the static Storybook site.
 - **`npm run build`** – create an optimized production build in the `build` directory.
 - **`npm run generate-meta`** – update `public/sitemap.xml` and `LLMs.txt` based on the current routes.
+- SEO metadata for each page is managed through the `PageMeta` component in `src/components`.
 
 ## Deployment
 

--- a/src/components/PageMeta.tsx
+++ b/src/components/PageMeta.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+interface PageMetaProps {
+  title: string;
+  description?: string;
+  path?: string;
+}
+
+const PageMeta: React.FC<PageMetaProps> = ({ title, description, path }) => {
+  const url = typeof window !== 'undefined'
+    ? `${window.location.origin}${path || window.location.pathname}`
+    : `https://randomgorsey.com${path || ''}`;
+  return (
+    <Helmet>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+      <link rel="canonical" href={url} />
+      <meta property="og:title" content={title} />
+      {description && <meta property="og:description" content={description} />}
+      <meta property="og:url" content={url} />
+      <meta property="og:type" content="website" />
+    </Helmet>
+  );
+};
+
+export default PageMeta;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import styles from './About.module.css';
 import Spinner from '../components/Spinner';
+import PageMeta from '../components/PageMeta';
 
 const About: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
@@ -11,7 +12,9 @@ const About: React.FC = () => {
   };
 
   return (
-    <motion.div
+    <>
+      <PageMeta title="About | Random Gorsey" description="Learn more about Random Gorsey and projects." path="/about" />
+      <motion.div
       className={styles['about-container']}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -46,6 +49,7 @@ const About: React.FC = () => {
           </li>
           </ul>
     </motion.div>
+    </>
   );
 };
 

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -9,6 +9,7 @@ import { PaperAirplaneIcon } from '@heroicons/react/24/solid';
 import Spinner from '../components/Spinner';
 import { contactFormSchema } from '../utils/validation';
 import Button from '../components/Button';
+import PageMeta from '../components/PageMeta';
 
 const Contact: React.FC = () => {
   const [message, setMessage] = useState('');
@@ -89,7 +90,9 @@ const Contact: React.FC = () => {
   };
 
   return (
-    <motion.div
+    <>
+      <PageMeta title="Contact | Random Gorsey" description="Get in touch with Random Gorsey." path="/contact" />
+      <motion.div
       className={styles['contact-container']}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -179,6 +182,7 @@ const Contact: React.FC = () => {
         </>
       )}
     </motion.div>
+    </>
   );
 };
 

--- a/src/pages/Discography.tsx
+++ b/src/pages/Discography.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import styles from './Discography.module.css';
 import SoLong from '../images/solongspectrum.jpg';
 import Customer from '../images/CustomerIsAlwaysRight.jpg';
+import PageMeta from '../components/PageMeta';
 
 interface Release {
   title: string;
@@ -24,12 +25,14 @@ const releases: Release[] = [
 ];
 
 const Discography: React.FC = () => (
-  <motion.div
-    className={styles['discography-container']}
-    initial={{ opacity: 0, y: 20 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ duration: 0.4 }}
-  >
+  <>
+    <PageMeta title="Discography | Random Gorsey" description="Releases by Random Gorsey." path="/discography" />
+    <motion.div
+      className={styles['discography-container']}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+    >
     <h2>Discography</h2>
     <div className={styles['release-grid']}>
       {releases.map((release) => (
@@ -48,6 +51,7 @@ const Discography: React.FC = () => (
       ))}
     </div>
   </motion.div>
+  </>
 );
 
 export default Discography;

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -5,6 +5,7 @@ import styles from './Gallery.module.css';
 import Spinner from '../components/Spinner';
 import galleryImages from '../data/galleryImages';
 import Caption from '../components/Caption';
+import PageMeta from '../components/PageMeta';
 
 type GalleryProps = {
   onOverlayStateChange?: (state: boolean) => void;
@@ -60,7 +61,9 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
   };
 
   return (
-    <motion.div
+    <>
+      <PageMeta title="Gallery | Random Gorsey" description="Browse the Random Gorsey photo gallery." path="/gallery" />
+      <motion.div
       className={styles['gallery-container']}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -108,6 +111,7 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
         </AnimatePresence>
       </div>
     </motion.div>
+    </>
   );
 };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PageMeta from '../components/PageMeta';
 import { motion } from 'framer-motion';
 import styles from './Home.module.css';
 import Spinner from '../components/Spinner';
@@ -51,7 +52,9 @@ const Home: React.FC = () => {
   }, [autoLoads]);
 
   return (
-    <motion.div
+    <>
+      <PageMeta title="Random Gorsey" description="Random Gorsey words and music." path="/" />
+      <motion.div
       className={styles['home-container']}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -79,6 +82,7 @@ const Home: React.FC = () => {
         </div>
       )}
     </motion.div>
+    </>
   );
 };
 

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import styles from './Listen.module.css';
 import Spinner from '../components/Spinner';
+import PageMeta from '../components/PageMeta';
 
 const Listen: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
@@ -11,7 +12,9 @@ const Listen: React.FC = () => {
   };
 
   return (
-    <motion.div
+    <>
+      <PageMeta title="Listen | Random Gorsey" description="Listen to tracks and playlists from Random Gorsey." path="/listen" />
+      <motion.div
       className={styles['listen-container']}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -45,6 +48,7 @@ const Listen: React.FC = () => {
         <a href="https://soundcloud.com/randomgorsey" title="Random Gorsey" target="_blank" rel="noreferrer" style={{ color: '#cccccc', textDecoration: 'none' }}>Random Gorsey</a> · <a href="https://soundcloud.com/randomgorsey/sets/tuunz" title="Tuunz" target="_blank" rel="noreferrer" style={{ color: '#cccccc', textDecoration: 'none' }}>Tuunz</a>
       </div>
     </motion.div>
+    </>
   );
 };
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import styles from './NotFound.module.css';
 import Spinner from '../components/Spinner';
+import PageMeta from '../components/PageMeta';
  
 
 const NotFound: React.FC = () => {
@@ -13,7 +14,9 @@ const NotFound: React.FC = () => {
   }, []);
 
   return (
-    <motion.div
+    <>
+      <PageMeta title="404 - Page Not Found" description="The page you requested could not be found." path="/" />
+      <motion.div
       className={styles['notfound-container']}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -27,6 +30,7 @@ const NotFound: React.FC = () => {
       {!loading && <h2 data-testid="not-found-title">404 - Page Not Found</h2>}
       {!loading && <p className={styles['notfound-description']}>Sorry, the page you're looking for does not exist.</p>}
     </motion.div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a reusable `PageMeta` component for Open Graph/SEO tags
- include `PageMeta` on all pages
- document SEO metadata component in README

## Testing
- `CI=true npm test --silent` *(fails: Fatal JavaScript invalid size error)*

------
https://chatgpt.com/codex/tasks/task_e_68558c05b4c8832ea614447f5b785c86