### PR TITLE
Remove canonical from template

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,6 @@
     <meta name="twitter:title" content="Random Gorsey" />
     <meta name="twitter:description" content="Random Gorsey words and music." />
     <meta name="twitter:image" content="/images/og.jpg" />
-    <link rel="canonical" href="https://randomgorsey.com" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- remove static canonical link from `public/index.html`
- keep canonical links generated at runtime by `<PageMeta>`

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND: cannot find module 'jest-util')*


------
https://chatgpt.com/codex/tasks/task_e_68563ab05474832e8274737fdba03580