### PR TITLE
Enable BrowserRouter SPA routing

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,7 +2,7 @@ jest.mock('react-router-dom', () => {
   const actualReactRouterDom = jest.requireActual('react-router-dom');
   return {
     ...actualReactRouterDom,
-    HashRouter: ({ children }) => <div>{children}</div>,
+    BrowserRouter: ({ children }) => <div>{children}</div>,
     Routes: ({ children }) => <div>{children}</div>,
     Route: ({ element }) => element,
   };

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Random Gorsey words, visuals and music. Random Gorsey is an experimental audiovisual artist who pushes the boundaries of creativity and generative art. Witness a landscape of spontaneous creation and exploratory design. On the agenda are live sets and a curated collection of coding sessions, Ableton trickery tutorials, reactive visualizations, and electronic soundscapes that evolve in response to user interaction. Whether you’re an electronic music enthusiast, a visual artist, or just curious about experimental web experiences, you’ll find interesting blog posts, behind-the-scenes tutorial breakdowns, downloadable presets, and open source code repositories. Stay up to date with an ever expanding event calendar featuring pop-up performances, collaborative art exhibitions, and virtual listening sessions. Connect via integrated social feeds and community forums where fellow creators share tips, patches, and track releases. Random Gorsey is your gateway to a living laboratory of glitch aesthetics and futuristic sound exploration on the web." />
+    <meta name="keywords" content="Random Gorsey, music, lo-fi house, electronic music, Helsinki" />
+    <meta name="author" content="Random Gorsey" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Random Gorsey</title>
+    <meta name="google-site-verification" content="pC4Zl0-9Z2GoscmvHFsdbyWxMRtImo2CDnZ5ht0G9Vs" />
+    <meta property="og:image" content="/images/og.jpg" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Random Gorsey" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Random Gorsey" />
+    <meta name="twitter:description" content="Random Gorsey words and music." />
+    <meta name="twitter:image" content="/images/og.jpg" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Random Gorsey",
+        "url": "https://randomgorsey.com",
+        "description": "Random Gorsey — Music and Projects."
+      }
+    </script>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    
+  </body>
+</html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,7 +8,7 @@ jest.mock('react-router-dom', () => {
   return {
     __esModule: true,
     ...originalModule,
-    HashRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import About from './pages/About';
 import Contact from './pages/Contact';
 import Footer from './patterns/Footer';
@@ -21,7 +21,7 @@ const App: React.FC = () => {
   };
 
   return (
-    <HashRouter>
+    <BrowserRouter>
       <div className={styles.app}>
         <Header />
         <Routes>
@@ -36,7 +36,7 @@ const App: React.FC = () => {
         {!isOverlayActive && <Footer />}
         <CookieConsent />
       </div>
-    </HashRouter>
+    </BrowserRouter>
   );
 };
 


### PR DESCRIPTION
## Description
- use BrowserRouter instead of HashRouter
- copy `index.html` to `404.html` for GitHub Pages SPA routing
- adjust Jest router mocks and tests

## 🤖 Testing
- `npm run lint` *(fails: Cannot find module css-tree/lib/version.js)*
- `npm test` *(fails with Node.js fatal error)*

------
https://chatgpt.com/codex/tasks/task_e_68584cf77494832eac560f4d5635cb96