### PR TITLE
Add minimist override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20349,13 +20349,6 @@
         "mime": "cli.js"
       }
     },
-    "node_modules/react-snap/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/react-snap/node_modules/mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -99,5 +99,8 @@
     "stylelint": "^16.20.0",
     "stylelint-config-css-modules": "^4.4.0",
     "stylelint-config-standard": "^38.0.0"
+  },
+  "overrides": {
+    "minimist": "^1.2.8"
   }
 }


### PR DESCRIPTION
## Summary
- update package.json to override minimist version
- run npm install to regenerate lockfile

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/randomgorsey/node_modules/semver/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_685a7c70528c832eb25de974a7bb34a5