### PR TITLE
Fix iOS crash by disabling videos if WebM unsupported

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import styles from './About.module.css';
 import Spinner from '../components/Spinner';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 
 const About: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
@@ -14,24 +15,26 @@ const About: React.FC = () => {
   return (
     <>
       <PageMeta title="About | Random Gorsey" description="Background, influences and side projects of Random Gorsey." path="/about" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/promo_canvas.webm')} type="video/webm" />
-      </video>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/promo_canvas.webm')} type="video/webm" />
+        </video>
+      )}
       <motion.div
       className={styles['about-container']}
       initial={{ opacity: 0, y: 20 }}
@@ -41,19 +44,23 @@ const About: React.FC = () => {
       {loading && <Spinner style={{ borderTopColor: '#FFD600' }} />}
 
       <h1>About</h1>
-            <figure>
-        <video
-          title="Portrait of Random Gorsey"
-          autoPlay
-          muted
-          loop
-          controls={false}
-          style={{ width: '10vw', borderRadius: '50%' }}
-          onLoadedData={handleContentLoad}
-        >
-          <source src="/images/portrait.webm" type="video/webm" />
-          <img src="/images/portrait.jpg" alt="Portrait of Random Gorsey" />
-        </video>
+      <figure>
+        {isWebMSupported() ? (
+          <video
+            title="Portrait of Random Gorsey"
+            autoPlay
+            muted
+            loop
+            controls={false}
+            style={{ width: '10vw', borderRadius: '50%' }}
+            onLoadedData={handleContentLoad}
+          >
+            <source src="/images/portrait.webm" type="video/webm" />
+            <img src="/images/portrait.jpg" alt="Portrait of Random Gorsey" />
+          </video>
+        ) : (
+          <img src="/images/portrait.jpg" alt="Portrait of Random Gorsey" onLoad={handleContentLoad} />
+        )}
       </figure>
 
     <p className={styles['about-description']}>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -10,6 +10,7 @@ import Spinner from '../components/Spinner';
 import { contactFormSchema } from '../utils/validation';
 import Button from '../components/Button';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 
 const Contact: React.FC = () => {
   const [message, setMessage] = useState('');
@@ -89,24 +90,26 @@ const Contact: React.FC = () => {
   return (
     <>
       <PageMeta title="Contact | Random Gorsey" description="Send a message to Random Gorsey." path="/contact" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/contact_canvas.webm')} type="video/webm" />
-      </video>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/contact_canvas.webm')} type="video/webm" />
+        </video>
+      )}
       <motion.div
       className={styles['contact-container']}
       initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Discography.tsx
+++ b/src/pages/Discography.tsx
@@ -4,6 +4,7 @@ import styles from './Discography.module.css';
 import SoLong from '../images/solongspectrum.jpg';
 import Customer from '../images/CustomerIsAlwaysRight.jpg';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 
 interface Release {
   title: string;
@@ -27,14 +28,15 @@ const releases: Release[] = [
 const Discography: React.FC = () => (
   <>
     <PageMeta title="Discography | Random Gorsey" description="Browse the official releases from Random Gorsey." path="/discography" />
-    {/* Background looping video */}
-    <video
-      autoPlay
-      muted
-      loop
-      playsInline
-      style={{          
-        position: 'fixed',
+    {/* Background looping video (disabled if WebM unsupported) */}
+    {isWebMSupported() && (
+      <video
+        autoPlay
+        muted
+        loop
+        playsInline
+        style={{
+          position: 'fixed',
           top: 0,
           left: 0,
           width: '100%',
@@ -42,10 +44,11 @@ const Discography: React.FC = () => (
           objectFit: 'cover',
           zIndex: -1,
 
-      }}
-    >
-      <source src={require('../videos/FIRGO002_canvas.webm')} type="video/webm" />
-    </video>
+        }}
+      >
+        <source src={require('../videos/FIRGO002_canvas.webm')} type="video/webm" />
+      </video>
+    )}
     <motion.div
       className={styles['discography-container']}
       initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -6,6 +6,7 @@ import Spinner from '../components/Spinner';
 import galleryImages from '../data/galleryImages';
 import Caption from '../components/Caption';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 
 type GalleryProps = {
   onOverlayStateChange?: (state: boolean) => void;
@@ -63,24 +64,26 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
   return (
     <>
       <PageMeta title="Gallery | Random Gorsey" description="Photo gallery featuring Random Gorsey visuals." path="/gallery" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/logo_canvas.webm')} type="video/webm" />
-      </video>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/logo_canvas.webm')} type="video/webm" />
+        </video>
+      )}
       <motion.div
       className={styles['gallery-container']}
       initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 import { motion } from 'framer-motion';
 import styles from './Home.module.css';
 import Spinner from '../components/Spinner';
@@ -54,24 +55,26 @@ const Home: React.FC = () => {
   return (
     <>
       <PageMeta title="Random Gorsey" description="Explore Random Gorsey's latest music and posts." path="/" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/home_canvas.webm')} type="video/webm" />
-      </video>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/home_canvas.webm')} type="video/webm" />
+        </video>
+      )}
       <motion.div
       className={styles['home-container']}
       initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import styles from './Listen.module.css';
 import Spinner from '../components/Spinner';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 
 const Listen: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
@@ -14,24 +15,26 @@ const Listen: React.FC = () => {
   return (
     <>
       <PageMeta title="Listen | Random Gorsey" description="Stream songs and playlists from Random Gorsey." path="/listen" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
-      </video>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
+        </video>
+      )}
       <motion.div
       className={styles['listen-container']}
       initial={{ opacity: 0, y: 20 }}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import styles from './NotFound.module.css';
 import Spinner from '../components/Spinner';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 import { Link } from 'react-router-dom';
 import Button from '../components/Button';
  
@@ -18,24 +19,26 @@ const NotFound: React.FC = () => {
   return (
     <>
       <PageMeta title="404 - Page Not Found" description="The page you requested could not be found." path="/" />
-      {/* Background looping video (same as Listen page) */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
-      </video>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
+        </video>
+      )}
       <motion.div
       className={styles['notfound-container']}
       initial={{ opacity: 0, y: 20 }}

--- a/src/utils/isWebMSupported.ts
+++ b/src/utils/isWebMSupported.ts
@@ -1,0 +1,5 @@
+export function isWebMSupported(): boolean {
+  if (typeof document === 'undefined') return false;
+  const video = document.createElement('video');
+  return video.canPlayType('video/webm') !== '';
+}


### PR DESCRIPTION
## Summary
- add helper to detect WebM video support
- hide background videos on Listen, Home, Gallery, Discography and NotFound when WebM isn't supported
- also hide videos on About and Contact pages on unsupported browsers

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/randomgorsey/node_modules/semver/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_685b168b885c832eaa72435c9da430fa