### PR TITLE
Fix iPhone infinite loop by disabling framer-motion

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,9 +3,13 @@ import { motion } from 'framer-motion';
 import styles from './About.module.css';
 import Spinner from '../components/Spinner';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
+import { isIOS } from '../utils/isIOS';
 
 const About: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
+
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
 
   const handleContentLoad = () => {
     setLoading(false);
@@ -14,46 +18,54 @@ const About: React.FC = () => {
   return (
     <>
       <PageMeta title="About | Random Gorsey" description="Background, influences and side projects of Random Gorsey." path="/about" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
-      >
-        <source src={require('../videos/promo_canvas.webm')} type="video/webm" />
-      </video>
-      <motion.div
-      className={styles['about-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
-      {loading && <Spinner style={{ borderTopColor: '#FFD600' }} />}
-
-      <h1>About</h1>
-            <figure>
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
         <video
-          title="Portrait of Random Gorsey"
           autoPlay
           muted
           loop
-          controls={false}
-          style={{ width: '10vw', borderRadius: '50%' }}
-          onLoadedData={handleContentLoad}
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
         >
-          <source src="/images/portrait.webm" type="video/webm" />
-          <img src="/images/portrait.jpg" alt="Portrait of Random Gorsey" />
+          <source src={require('../videos/promo_canvas.webm')} type="video/webm" />
         </video>
+      )}
+      <Container
+        className={styles['about-container']}
+        {...(!isIOS() && {
+          initial: { opacity: 0, y: 20 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.4 },
+        })}
+      >
+      {loading && <Spinner style={{ borderTopColor: '#FFD600' }} />}
+
+      <h1>About</h1>
+      <figure>
+        {isWebMSupported() ? (
+          <video
+            title="Portrait of Random Gorsey"
+            autoPlay
+            muted
+            loop
+            controls={false}
+            style={{ width: '10vw', borderRadius: '50%' }}
+            onLoadedData={handleContentLoad}
+          >
+            <source src="/images/portrait.webm" type="video/webm" />
+            <img src="/images/portrait.jpg" alt="Portrait of Random Gorsey" />
+          </video>
+        ) : (
+          <img src="/images/portrait.jpg" alt="Portrait of Random Gorsey" onLoad={handleContentLoad} />
+        )}
       </figure>
 
     <p className={styles['about-description']}>
@@ -77,7 +89,7 @@ const About: React.FC = () => {
             </a>
           </li>
           </ul>
-    </motion.div>
+    </Container>
     </>
   );
 };

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -10,6 +10,8 @@ import Spinner from '../components/Spinner';
 import { contactFormSchema } from '../utils/validation';
 import Button from '../components/Button';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
+import { isIOS } from '../utils/isIOS';
 
 const Contact: React.FC = () => {
   const [message, setMessage] = useState('');
@@ -20,6 +22,8 @@ const Contact: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
   const [sending, setSending] = useState(false);
   const [formErrors, setFormErrors] = useState<{ name?: string; email?: string; subject?: string; message?: string }>({});
+
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
 
   React.useEffect(() => {
     const timer = setTimeout(() => setLoading(false), 1000);
@@ -89,30 +93,34 @@ const Contact: React.FC = () => {
   return (
     <>
       <PageMeta title="Contact | Random Gorsey" description="Send a message to Random Gorsey." path="/contact" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/contact_canvas.webm')} type="video/webm" />
+        </video>
+      )}
+      <Container
+        className={styles['contact-container']}
+        {...(!isIOS() && {
+          initial: { opacity: 0, y: 20 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.4 },
+        })}
       >
-        <source src={require('../videos/contact_canvas.webm')} type="video/webm" />
-      </video>
-      <motion.div
-      className={styles['contact-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
       {loading && <Spinner />}
       {sending && <Spinner />}
       {!loading && !sending && (
@@ -197,7 +205,7 @@ const Contact: React.FC = () => {
           )}
         </>
       )}
-    </motion.div>
+    </Container>
     </>
   );
 };

--- a/src/pages/Discography.tsx
+++ b/src/pages/Discography.tsx
@@ -4,6 +4,8 @@ import styles from './Discography.module.css';
 import SoLong from '../images/solongspectrum.jpg';
 import Customer from '../images/CustomerIsAlwaysRight.jpg';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
+import { isIOS } from '../utils/isIOS';
 
 interface Release {
   title: string;
@@ -24,17 +26,21 @@ const releases: Release[] = [
   },
 ];
 
-const Discography: React.FC = () => (
+const Discography: React.FC = () => {
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
+
+  return (
   <>
     <PageMeta title="Discography | Random Gorsey" description="Browse the official releases from Random Gorsey." path="/discography" />
-    {/* Background looping video */}
-    <video
-      autoPlay
-      muted
-      loop
-      playsInline
-      style={{          
-        position: 'fixed',
+    {/* Background looping video (disabled if WebM unsupported) */}
+    {isWebMSupported() && (
+      <video
+        autoPlay
+        muted
+        loop
+        playsInline
+        style={{
+          position: 'fixed',
           top: 0,
           left: 0,
           width: '100%',
@@ -42,15 +48,18 @@ const Discography: React.FC = () => (
           objectFit: 'cover',
           zIndex: -1,
 
-      }}
-    >
-      <source src={require('../videos/FIRGO002_canvas.webm')} type="video/webm" />
-    </video>
-    <motion.div
+        }}
+      >
+        <source src={require('../videos/FIRGO002_canvas.webm')} type="video/webm" />
+      </video>
+    )}
+    <Container
       className={styles['discography-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
+      {...(!isIOS() && {
+        initial: { opacity: 0, y: 20 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.4 },
+      })}
     >
       <h1 className={styles['discography-title']}><span className={styles['disco-break']}>Disco-</span>graphy</h1>
     <div className={styles['release-grid']}>
@@ -86,8 +95,9 @@ const Discography: React.FC = () => (
         );
       })}
     </div>
-  </motion.div>
+  </Container>
   </>
-);
+  );
+};
 
 export default Discography;

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -6,6 +6,8 @@ import Spinner from '../components/Spinner';
 import galleryImages from '../data/galleryImages';
 import Caption from '../components/Caption';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
+import { isIOS } from '../utils/isIOS';
 
 type GalleryProps = {
   onOverlayStateChange?: (state: boolean) => void;
@@ -15,6 +17,8 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
   const [overlayImage, setOverlayImage] = useState<string | null>(null);
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const [loading, setLoading] = React.useState(true);
+
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
 
   const images = useMemo(() => galleryImages, []);
 
@@ -63,30 +67,34 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
   return (
     <>
       <PageMeta title="Gallery | Random Gorsey" description="Photo gallery featuring Random Gorsey visuals." path="/gallery" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/logo_canvas.webm')} type="video/webm" />
+        </video>
+      )}
+      <Container
+        className={styles['gallery-container']}
+        {...(!isIOS() && {
+          initial: { opacity: 0, y: 20 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.4 },
+        })}
       >
-        <source src={require('../videos/logo_canvas.webm')} type="video/webm" />
-      </video>
-      <motion.div
-      className={styles['gallery-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
       {loading && <Spinner />}
       <div className={styles['gallery-content']}>
         <h1>Gallery</h1>
@@ -107,30 +115,46 @@ const Gallery: React.FC<GalleryProps> = ({ onOverlayStateChange }) => {
 
         <AnimatePresence>
         {overlayImage && (
-          <motion.div
-            className={styles['overlay']}
-            onClick={closeOverlay}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.3 }}
-          >
-            <XMarkIcon className={styles['close-icon']} onClick={closeOverlay} />
-            <ArrowLeftIcon aria-label="Previous image" className={styles['left-icon']} onClick={(e) => { e.stopPropagation(); navigateLeft(); }} />
-            <img
-              src={overlayImage}
-              alt={images[currentIndex].caption}
-              title={images[currentIndex].caption}
-              style={{ width: '100%' }}
-              onClick={(e) => { e.stopPropagation(); navigateRight(); }}
-            />
-            <Caption>{images[currentIndex].caption}</Caption>
-            <ArrowRightIcon aria-label="Next image" className={styles['right-icon']} onClick={(e) => { e.stopPropagation(); navigateRight(); }} />
-          </motion.div>
+          isIOS() ? (
+            <div className={styles['overlay']} onClick={closeOverlay}>
+              <XMarkIcon className={styles['close-icon']} onClick={closeOverlay} />
+              <ArrowLeftIcon aria-label="Previous image" className={styles['left-icon']} onClick={(e) => { e.stopPropagation(); navigateLeft(); }} />
+              <img
+                src={overlayImage}
+                alt={images[currentIndex].caption}
+                title={images[currentIndex].caption}
+                style={{ width: '100%' }}
+                onClick={(e) => { e.stopPropagation(); navigateRight(); }}
+              />
+              <Caption>{images[currentIndex].caption}</Caption>
+              <ArrowRightIcon aria-label="Next image" className={styles['right-icon']} onClick={(e) => { e.stopPropagation(); navigateRight(); }} />
+            </div>
+          ) : (
+            <motion.div
+              className={styles['overlay']}
+              onClick={closeOverlay}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <XMarkIcon className={styles['close-icon']} onClick={closeOverlay} />
+              <ArrowLeftIcon aria-label="Previous image" className={styles['left-icon']} onClick={(e) => { e.stopPropagation(); navigateLeft(); }} />
+              <img
+                src={overlayImage}
+                alt={images[currentIndex].caption}
+                title={images[currentIndex].caption}
+                style={{ width: '100%' }}
+                onClick={(e) => { e.stopPropagation(); navigateRight(); }}
+              />
+              <Caption>{images[currentIndex].caption}</Caption>
+              <ArrowRightIcon aria-label="Next image" className={styles['right-icon']} onClick={(e) => { e.stopPropagation(); navigateRight(); }} />
+            </motion.div>
+          )
         )}
         </AnimatePresence>
       </div>
-    </motion.div>
+    </Container>
     </>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
 import { motion } from 'framer-motion';
 import styles from './Home.module.css';
 import Spinner from '../components/Spinner';
 import Button from '../components/Button';
 import PostCard, { Post } from '../components/PostCard';
+import { isIOS } from '../utils/isIOS';
 
 // Dynamically import all posts from the posts folder using require.context
 // @ts-ignore
@@ -20,6 +22,8 @@ const Home: React.FC = () => {
   const [visibleCount, setVisibleCount] = React.useState(3);
   const [autoLoads, setAutoLoads] = React.useState(0);
   const sentinelRef = React.useRef<HTMLDivElement | null>(null);
+
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
 
   React.useEffect(() => {
     const timer = setTimeout(() => setLoading(false), 1000);
@@ -54,30 +58,34 @@ const Home: React.FC = () => {
   return (
     <>
       <PageMeta title="Random Gorsey" description="Explore Random Gorsey's latest music and posts." path="/" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/home_canvas.webm')} type="video/webm" />
+        </video>
+      )}
+      <Container
+        className={styles['home-container']}
+        {...(!isIOS() && {
+          initial: { opacity: 0, y: 20 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.4 },
+        })}
       >
-        <source src={require('../videos/home_canvas.webm')} type="video/webm" />
-      </video>
-      <motion.div
-      className={styles['home-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
       {loading && <Spinner style={{ borderTopColor: '#FFD600' }} />}
       {!loading && (
         <>
@@ -108,7 +116,7 @@ const Home: React.FC = () => {
           </Button>
         </div>
       )}
-    </motion.div>
+    </Container>
     </>
   );
 };

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -3,9 +3,13 @@ import { motion } from 'framer-motion';
 import styles from './Listen.module.css';
 import Spinner from '../components/Spinner';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
+import { isIOS } from '../utils/isIOS';
 
 const Listen: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
+
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
 
   const handleContentLoad = () => {
     setLoading(false);
@@ -14,30 +18,34 @@ const Listen: React.FC = () => {
   return (
     <>
       <PageMeta title="Listen | Random Gorsey" description="Stream songs and playlists from Random Gorsey." path="/listen" />
-      {/* Background looping video */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
+        </video>
+      )}
+      <Container
+        className={styles['listen-container']}
+        {...(!isIOS() && {
+          initial: { opacity: 0, y: 20 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.4 },
+        })}
       >
-        <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
-      </video>
-      <motion.div
-      className={styles['listen-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
       {loading && <Spinner />}
       <h1>Listen to Music</h1>
       <p className={styles['listen-description']}>Enjoy curated playlists and latest tracks.</p>
@@ -69,7 +77,7 @@ const Listen: React.FC = () => {
       <div style={{ fontSize: '10px', color: '#cccccc', lineBreak: 'anywhere', wordBreak: 'normal', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', fontFamily: 'Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif', fontWeight: 100 }}>
         <a href="https://soundcloud.com/randomgorsey" title="Random Gorsey" target="_blank" rel="noreferrer" style={{ color: '#cccccc', textDecoration: 'none' }}>Random Gorsey</a> · <a href="https://soundcloud.com/randomgorsey/sets/tuunz" title="Tuunz" target="_blank" rel="noreferrer" style={{ color: '#cccccc', textDecoration: 'none' }}>Tuunz</a>
       </div>
-    </motion.div>
+    </Container>
     </>
   );
 };

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -3,12 +3,16 @@ import { motion } from 'framer-motion';
 import styles from './NotFound.module.css';
 import Spinner from '../components/Spinner';
 import PageMeta from '../components/PageMeta';
+import { isWebMSupported } from '../utils/isWebMSupported';
+import { isIOS } from '../utils/isIOS';
 import { Link } from 'react-router-dom';
 import Button from '../components/Button';
  
 
 const NotFound: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
+
+  const Container: React.ElementType = isIOS() ? 'div' : motion.div;
 
   React.useEffect(() => {
     const timer = window.requestAnimationFrame(() => setLoading(false));
@@ -18,30 +22,34 @@ const NotFound: React.FC = () => {
   return (
     <>
       <PageMeta title="404 - Page Not Found" description="The page you requested could not be found." path="/" />
-      {/* Background looping video (same as Listen page) */}
-      <video
-        autoPlay
-        muted
-        loop
-        playsInline
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          zIndex: -1,
-        }}
+      {/* Background looping video (disabled if WebM unsupported) */}
+      {isWebMSupported() && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            zIndex: -1,
+          }}
+        >
+          <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
+        </video>
+      )}
+      <Container
+        className={styles['notfound-container']}
+        {...(!isIOS() && {
+          initial: { opacity: 0, y: 20 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.4 },
+        })}
       >
-        <source src={require('../videos/rg-glitch-bg.webm')} type="video/webm" />
-      </video>
-      <motion.div
-      className={styles['notfound-container']}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
       {loading && <Spinner />}
       {!loading && <h1 data-testid="not-found-title">404 - Page Not Found</h1>}
       {!loading && <p className={styles['notfound-description']}>Sorry, the page you're looking for does not exist.😢</p>}
@@ -55,7 +63,7 @@ const NotFound: React.FC = () => {
           </Button>
         </Link>
       </div>
-    </motion.div>
+    </Container>
     </>
   );
 };

--- a/src/utils/isIOS.ts
+++ b/src/utils/isIOS.ts
@@ -1,0 +1,7 @@
+export function isIOS(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || navigator.vendor || (window as any).opera;
+  // iPadOS detection
+  const iPadOS = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+  return /iPad|iPhone|iPod/.test(ua) || iPadOS;
+}

--- a/src/utils/isWebMSupported.ts
+++ b/src/utils/isWebMSupported.ts
@@ -1,0 +1,5 @@
+export function isWebMSupported(): boolean {
+  if (typeof document === 'undefined') return false;
+  const video = document.createElement('video');
+  return video.canPlayType('video/webm') !== '';
+}


### PR DESCRIPTION
## Summary
- add helper to detect iOS
- use regular divs on iOS instead of framer-motion components
- keep video fallback logic when WebM isn't supported

## Testing
- `npm test --silent` *(fails: Cannot find module './invariant')*

------
https://chatgpt.com/codex/tasks/task_e_685b168b885c832eaa72435c9da430fa