### PR TITLE
Add strict stylelint rule for hardcoded values

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": ["stylelint-config-standard", "stylelint-config-css-modules"],
+  "plugins": ["stylelint-declaration-strict-value"],
   "rules": {
     "max-nesting-depth": 3,
     "selector-max-id": 0,
@@ -18,6 +19,16 @@
     "value-no-vendor-prefix": true,
     "function-url-no-scheme-relative": true,
     "no-empty-source": true,
-    "no-invalid-double-slash-comments": true
+    "no-invalid-double-slash-comments": true,
+    "scale-unlimited/declaration-strict-value": [
+      ["/color/", "z-index"],
+      {
+        "ignoreValues": {
+          "/color/": ["inherit", "transparent", "currentcolor"],
+          "": ["auto", "0"]
+        },
+        "severity": "warning"
+      }
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The site will be available at [http://localhost:3000](http://localhost:3000). An
 ## Useful Scripts
 
 - **`npm test`** – run unit tests using React Testing Library.
-- **`npm run lint`** – format and lint the CSS files with stylelint.
+- **`npm run lint`** – format and lint the CSS files and inline styles with stylelint.
 - **`npm run storybook`** – launch the component Storybook on port 6006.
 - **`npm run build-storybook`** – generate the static Storybook site.
 - **`npm run build`** – create an optimized production build and pre-render each route using `react-snap`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-storybook": "^9.0.12",
         "gh-pages": "^6.3.0",
+        "postcss-js": "^4.0.1",
         "prop-types": "^15.8.1",
         "react-scripts": "^5.0.1",
         "react-snap": "^1.23.0",
@@ -48,7 +49,8 @@
         "storybook": "^9.0.12",
         "stylelint": "^16.20.0",
         "stylelint-config-css-modules": "^4.4.0",
-        "stylelint-config-standard": "^38.0.0"
+        "stylelint-config-standard": "^38.0.0",
+        "stylelint-declaration-strict-value": "^1.10.11"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -22406,6 +22408,19 @@
       },
       "peerDependencies": {
         "stylelint": "^16.18.0"
+      }
+    },
+    "node_modules/stylelint-declaration-strict-value": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.10.11.tgz",
+      "integrity": "sha512-oVQvhZlFZAiDz9r2BPFZLtTGm1A2JVhdKObKAJoTjFfR4F/NpApC4bMBTxf4sZS76Na3njYKVOaAaKSZ4+FU+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": ">=7 <=16"
       }
     },
     "node_modules/stylelint-scss": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "react-scripts start",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "stylelint 'src/**/*.css' --fix",
+    "lint": "stylelint 'src/**/*.css' --fix && stylelint 'src/**/*.{ts,tsx}' --custom-syntax postcss-js --fix",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "generate-meta": "node scripts/generate-meta.js"
@@ -98,7 +98,9 @@
     "storybook": "^9.0.12",
     "stylelint": "^16.20.0",
     "stylelint-config-css-modules": "^4.4.0",
-    "stylelint-config-standard": "^38.0.0"
+    "stylelint-config-standard": "^38.0.0",
+    "stylelint-declaration-strict-value": "^1.10.11",
+    "postcss-js": "^4.0.1"
   },
   "overrides": {
     "minimist": "^1.2.8"


### PR DESCRIPTION
## Summary
- warn about hardcoded values using `stylelint-declaration-strict-value`
- lint inline styles in JS/TS via `postcss-js`
- document new lint behaviour

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm test` *(fails: cannot find module './invariant')*

------
https://chatgpt.com/codex/tasks/task_e_686183e1d4dc832eb029dba9b367cb64